### PR TITLE
レシピ検索ページの雛形作成 #53 close

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'omniauth-rails_csrf_protection'
 # line-bot
 gem 'line-bot-api'
 
+gem 'rakuten_web_service'
+
 group :development, :test do
   # Debugging tools
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rakuten_web_service (1.13.2)
+      json (~> 2.3)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.1)
@@ -456,6 +458,7 @@ DEPENDENCIES
   rails (~> 7.1.3, >= 7.1.3.2)
   rails-erd
   rails-i18n
+  rakuten_web_service
   rspec-rails
   rubocop
   rubocop-checkstyle_formatter

--- a/app/controllers/rakuten_recipes_controller.rb
+++ b/app/controllers/rakuten_recipes_controller.rb
@@ -1,14 +1,16 @@
 class RakutenRecipesController < ApplicationController
   def search
-    @categories = RakutenWebService::Recipe.medium_categories
+    @categories = RakutenWebService::Recipe.small_categories
     @search = params[:keyword]
+
     if @search.present?
-      @filtered_categories = @categories.select { |category| category.name.include?(@search) }
-
-      @recipes = @categories.first.ranking
-
+      category = RakutenWebService::Recipe.small_categories.find { |c| c.name.match(@search) }
+      if category.nil?
+        @recipes = []
+        flash.now[:warning] = t('defaults.flash_message.not_searched')
+      else
+        @recipes = category.ranking
+      end
     end
   end
 end
-
-# カテゴリー一覧APIでカテゴリーを取得

--- a/app/controllers/rakuten_recipes_controller.rb
+++ b/app/controllers/rakuten_recipes_controller.rb
@@ -1,0 +1,14 @@
+class RakutenRecipesController < ApplicationController
+  def search
+    @categories = RakutenWebService::Recipe.medium_categories
+    @search = params[:keyword]
+    if @search.present?
+      @filtered_categories = @categories.select { |category| category.name.include?(@search) }
+
+      @recipes = @categories.first.ranking
+
+    end
+  end
+end
+
+# カテゴリー一覧APIでカテゴリーを取得

--- a/app/controllers/rakuten_recipes_controller.rb
+++ b/app/controllers/rakuten_recipes_controller.rb
@@ -1,6 +1,5 @@
 class RakutenRecipesController < ApplicationController
   def search
-    @categories = RakutenWebService::Recipe.small_categories
     @search = params[:keyword]
 
     if @search.present?

--- a/app/javascript/controllers/confirm_dialog_controller.js
+++ b/app/javascript/controllers/confirm_dialog_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="confirm-dialog"
+export default class extends Controller {
+  // connect() {
+  // }
+  confirm(event) {
+    event.preventDefault(); // デフォルトのリンク動作をキャンセル
+    if (confirm("外部サイトに移動しますか？")) {
+      window.open(event.target.href, '_blank'); // 新しいタブでリンクを開く
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import ConfirmDialogController from "./confirm_dialog_controller"
+application.register("confirm-dialog", ConfirmDialogController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/rakuten_recipes/search.html.erb
+++ b/app/views/rakuten_recipes/search.html.erb
@@ -1,14 +1,34 @@
-<h1>料理レシピ検索</h1>
-  <div>
+<div class="container mx-auto text-center">
+  <h1>人気レシピ検索</h1>
+  <div class='my-5'>
     <%= form_with url: search_path, method: :get, local: true do |f| %>
-      <%= f.text_field :keyword, required: true %>
-      <%= f.submit '検索する', disable_with: '検索中...' %>
-    <% end %>
-    <%# # 全種類の小カテゴリーを表示 %>
-    <% if @search.present? %>
-      <% @filtered_categories.each do |category| %>
-        <%= category.name %>
-      <% end %>
+      <div class="field">
+        <div class="max-w-xs mx-auto">
+          <%= f.text_field :keyword, class: "input input-bordered w-full text-center" %>
+        </div>
+        <%= f.submit '検索する', disable_with: '検索中...', class: "btn btn-outline btn-success my-5" %>
+      </div>
     <% end %>
   </div>
-
+  <% if @search.present? %>
+    <div class="flex justify-center my-5">
+      <div class="grid grid-cols-1 sm:grid-cols-2 2xl:grid-cols-4 gap-20">
+        <% @recipes.each do |r| %>
+          <div class="card w-96 bg-base-100 shadow-xl">
+            <figure class="p-5 bg-primary-content" style="height: 241px;">
+              <%= image_tag r['foodImageUrl'], alt: r['recipe_title'], class: "rounded-lg"%>
+            </figure>
+            <div class="card-body items-center text-center">
+              <h2 class="card-title"><%= r['recipe_title'] %></h2>
+              <p>調理時間：<%= r['recipe_indication'] %></p>
+              <p>費用：<%= r['recipe_cost'] %></p>
+              <div class="card-actions">
+                <%= link_to "詳細", r['recipe_url'], class: "btn btn-outline btn-success btn-xs sm:btn-sm md:btn-md lg:btn-lg" %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/rakuten_recipes/search.html.erb
+++ b/app/views/rakuten_recipes/search.html.erb
@@ -1,0 +1,14 @@
+<h1>料理レシピ検索</h1>
+  <div>
+    <%= form_with url: search_path, method: :get, local: true do |f| %>
+      <%= f.text_field :keyword, required: true %>
+      <%= f.submit '検索する', disable_with: '検索中...' %>
+    <% end %>
+    <%# # 全種類の小カテゴリーを表示 %>
+    <% if @search.present? %>
+      <% @filtered_categories.each do |category| %>
+        <%= category.name %>
+      <% end %>
+    <% end %>
+  </div>
+

--- a/app/views/rakuten_recipes/search.html.erb
+++ b/app/views/rakuten_recipes/search.html.erb
@@ -23,7 +23,7 @@
               <p>調理時間：<%= r['recipe_indication'] %></p>
               <p>費用：<%= r['recipe_cost'] %></p>
               <div class="card-actions">
-                <%= link_to "詳細", r['recipe_url'], class: "btn btn-outline btn-success btn-xs sm:btn-sm md:btn-md lg:btn-lg" %>
+                  <%= link_to "詳細", r['recipe_url'], target: "_blank", rel: "noopener noreferrer", data: { controller: "confirm-dialog", action: "click->confirm-dialog#confirm" }, class: "btn btn-outline btn-info" %>
               </div>
             </div>
           </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,6 +9,7 @@
     <ul class="menu menu-horizontal px-1 text-lg">
       <li><%= link_to t('header.index'),foods_path %></li>
       <li><%= link_to t('header.food_new'),new_food_path %></li>
+      <li><%= link_to "レシピ検索",search_path %></li>
       <li>
         <details>
           <summary>ユーザー</summary>

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require_relative 'boot'
 
 require 'rails/all'
 require 'devise'
-
+require 'rakuten_web_service'
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/initializers/rakuten.rb
+++ b/config/initializers/rakuten.rb
@@ -1,0 +1,3 @@
+RakutenWebService.configure do |c|
+  c.application_id = ENV['RWS_APPLICATION_ID']
+end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,7 @@ ja:
       edit: "%{item}を編集しました"
       not_edit: "%{item}を編集できませんでした"
       deleted: "%{item}を削除しました"
+      not_searched: "検索結果がありません"
 
   header:
     title: PantryChefNotifier

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,4 +32,7 @@ Rails.application.routes.draw do
   end
 
   resources :foods
+
+  # rakuten
+    get 'search', to: 'rakuten_recipes#search'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_052709) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_07_082900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_052709) do
     t.string "name", null: false
     t.string "provider"
     t.string "uid"
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
実装内容
フロント
- [x] レシピ検索form
  - [x] text-fieldが表示されている
  - [x] テキストが入力できる
  - [x] 検索btnが表示されている
- [x] 検索結果
  - [x] レシピが４つ表示されている
  - [x] レシピ名が表示されている
  - [x] 調理時間が表示されている
  - [x] 費用が表示されている
  - [x] 詳細btnが表示されている
  - [x] 詳細btnをクリックすると確認ダイアログが表示される
  
バック
- [x] 食材名を入力し検索するとレシピランキング上位４つを取得できる
- [x] 入力したキーワードがで楽天レシピカテゴリ一覧API でnilの場合、フラッシュメッセージが表示される
- [x] 詳細btnに確認ダイアログ表示のためのjsを実装