### PR TITLE
食材の編集を食材の詳細画面でできるように変更 #61 close

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -32,11 +32,11 @@ class FoodsController < ApplicationController
   end
 
   def update
-    @food = Food.find(params[:id])
-    @food.update(food_params)
+    food = Food.find(params[:id])
+    food.update(food_params)
 
-    if @food.save
-      redirect_to foods_path, success: t('defaults.flash_message.edit', item: Food.model_name.human)
+    if food.save
+      redirect_to food_path(food)
     else
       flash.now[:warning] = t('defaults.flash_message.not_edit', item: Food.model_name.human)
       render :new, status: :unprocessable_entity

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,6 +10,9 @@ application.register("confirm-dialog", ConfirmDialogController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import InputNumberController from "./input_number_controller"
+application.register("input-number", InputNumberController)
+
 import SelectSubmitController from "./select_submit_controller"
 application.register("select-submit", SelectSubmitController)
 

--- a/app/javascript/controllers/input_number_controller.js
+++ b/app/javascript/controllers/input_number_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="input-number"
+export default class extends Controller {
+  static targets = ["input"];
+
+  decrease() {
+    let currentValue = parseInt(this.inputTarget.value);
+    if (currentValue > 0) {
+      this.inputTarget.value = currentValue - 1;
+    }
+  }
+
+  increase() {
+    let currentValue = parseInt(this.inputTarget.value);
+    this.inputTarget.value = currentValue + 1;
+  }
+}

--- a/app/views/foods/_edit_expiration_modal.html.erb
+++ b/app/views/foods/_edit_expiration_modal.html.erb
@@ -1,4 +1,4 @@
-<button class="btn grid flex-grow max-w-96 card bg-base-200 rounded-box place-items-center" onclick="expiration_modal.showModal()">
+<button class="btn grid flex-grow card bg-slate-50 rounded-box place-items-center" onclick="expiration_modal.showModal()">
   <%= food.expiration_date %>
 </button>
 <dialog id="expiration_modal" class="modal">

--- a/app/views/foods/_edit_expiration_modal.html.erb
+++ b/app/views/foods/_edit_expiration_modal.html.erb
@@ -1,0 +1,17 @@
+<button class="btn grid flex-grow max-w-96 card bg-base-200 rounded-box place-items-center" onclick="expiration_modal.showModal()">
+  <%= food.expiration_date %>
+</button>
+<dialog id="expiration_modal" class="modal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg mb-3">期限を設定</h3>
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+    <%= form_with model: food, local:true do |f|%>
+      <div class='flex items-center mx-auto max-w-xs'>
+        <%= f.date_field :expiration_date, class:"mx-auto text-center"%>
+      </div>
+      <%= f.submit "入力完了", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
+    <% end %>
+  </div>
+</dialog>

--- a/app/views/foods/_edit_expiration_modal.html.erb
+++ b/app/views/foods/_edit_expiration_modal.html.erb
@@ -1,6 +1,9 @@
-<button class="btn grid flex-grow card bg-slate-50 rounded-box place-items-center" onclick="expiration_modal.showModal()">
-  <%= food.expiration_date %>
+<button class="btn card bg-slate-50 rounded-box flex flex-row justify-between items-center w-full min-w-40 max-w-xs" onclick="expiration_modal.showModal()">
+  <span></span>
+  <span><%= food.expiration_date %></span>
+  <span>&gt;</span>
 </button>
+
 <dialog id="expiration_modal" class="modal">
   <div class="modal-box">
     <h3 class="font-bold text-lg mb-3">期限を設定</h3>
@@ -11,7 +14,7 @@
       <div class='flex items-center mx-auto max-w-xs'>
         <%= f.date_field :expiration_date, class:"mx-auto text-center"%>
       </div>
-      <%= f.submit "入力完了", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
+      <%= f.submit "変更する", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
     <% end %>
   </div>
 </dialog>

--- a/app/views/foods/_edit_name_modal.html.erb
+++ b/app/views/foods/_edit_name_modal.html.erb
@@ -1,5 +1,4 @@
-
-<button class="btn grid flex-grow h-32 max-w-96 card bg-base-200 rounded-box place-items-center" onclick="name_modal.showModal()">
+<button class="btn card bg-slate-50 rounded-box" onclick="name_modal.showModal()">
   <%= food.name %>
 </button>
 <dialog id="name_modal" class="modal">

--- a/app/views/foods/_edit_name_modal.html.erb
+++ b/app/views/foods/_edit_name_modal.html.erb
@@ -1,5 +1,8 @@
-<button class="btn card bg-slate-50 rounded-box" onclick="name_modal.showModal()">
-  <%= food.name %>
+<button class="btn card bg-slate-50 rounded-box flex flex-row justify-between items-center w-full min-w-40 max-w-xs" onclick="name_modal.showModal()">
+  <span class="flex-shrink-0"></span>
+  <span class="truncate flex-1 mx-2"><%= food.name %></span>
+  <span class="flex-shrink-0">&gt;</span>
+</button>
 </button>
 <dialog id="name_modal" class="modal">
   <div class="modal-box">
@@ -11,7 +14,7 @@
       <div class='flex items-center mx-auto max-w-xs'>
         <%= f.text_area :name, class:"textarea textarea-bordered w-full", placeholder: "食材名を入力" %>
       </div>
-      <%= f.submit "入力完了", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
+      <%= f.submit "変更する", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
     <% end %>
   </div>
 </dialog>

--- a/app/views/foods/_edit_name_modal.html.erb
+++ b/app/views/foods/_edit_name_modal.html.erb
@@ -1,0 +1,18 @@
+
+<button class="btn grid flex-grow h-32 max-w-96 card bg-base-200 rounded-box place-items-center" onclick="name_modal.showModal()">
+  <%= food.name %>
+</button>
+<dialog id="name_modal" class="modal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg mb-3">食材名を入力</h3>
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+    <%= form_with model: food, local:true do |f|%>
+      <div class='flex items-center mx-auto max-w-xs'>
+        <%= f.text_area :name, class:"textarea textarea-bordered w-full", placeholder: "食材名を入力" %>
+      </div>
+      <%= f.submit "入力完了", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
+    <% end %>
+  </div>
+</dialog>

--- a/app/views/foods/_edit_quantity_modal.html.erb
+++ b/app/views/foods/_edit_quantity_modal.html.erb
@@ -1,9 +1,9 @@
 
-<div class="grid flex-grow max-w-96 card rounded-box place-items-center">
+<div class="grid flex-grow card rounded-box place-items-center">
   <%= form_with model: food, local:true do |f|%>
     <div class="space-y-6">
       <div class="relative w-40" data-controller="input-number">
-        <button class="absolute left-0 top-0 rounded-r-none btn btn-square" data-action="click->input-number#decrease">-</button>
+        <button class="absolute left-0 top-0 rounded-r-none btn btn-square " data-action="click->input-number#decrease">-</button>
         <%= f.number_field :quantity, class: "w-full text-center px-12 input input-bordered", id: "input-number", data: { target: "input-number.input" }, min: 0%>
         <button class="absolute right-0 top-0 rounded-l-none btn btn-square" data-action="click->input-number#increase">+</button>
       </div>

--- a/app/views/foods/_edit_quantity_modal.html.erb
+++ b/app/views/foods/_edit_quantity_modal.html.erb
@@ -1,0 +1,13 @@
+
+<div class="grid flex-grow max-w-96 card bg-base-200 rounded-box place-items-center">
+  <%= form_with model: food, local:true do |f|%>
+    <div class="m-10 space-y-6">
+      <div class="relative w-40" data-controller="input-number">
+        <button class="absolute left-0 top-0 rounded-r-none btn btn-square" data-action="click->input-number#decrease">-</button>
+        <%= f.number_field :quantity, class: "w-full text-center px-12 input input-bordered", id: "input-number", data: { target: "input-number.input" }, min: 0%>
+
+        <button class="absolute right-0 top-0 rounded-l-none btn btn-square" data-action="click->input-number#increase">+</button>
+    </div>
+    <%= f.submit "入力完了", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
+  <% end %>
+</div>

--- a/app/views/foods/_edit_quantity_modal.html.erb
+++ b/app/views/foods/_edit_quantity_modal.html.erb
@@ -1,13 +1,12 @@
 
-<div class="grid flex-grow max-w-96 card bg-base-200 rounded-box place-items-center">
+<div class="grid flex-grow max-w-96 card rounded-box place-items-center">
   <%= form_with model: food, local:true do |f|%>
-    <div class="m-10 space-y-6">
+    <div class="space-y-6">
       <div class="relative w-40" data-controller="input-number">
         <button class="absolute left-0 top-0 rounded-r-none btn btn-square" data-action="click->input-number#decrease">-</button>
         <%= f.number_field :quantity, class: "w-full text-center px-12 input input-bordered", id: "input-number", data: { target: "input-number.input" }, min: 0%>
-
         <button class="absolute right-0 top-0 rounded-l-none btn btn-square" data-action="click->input-number#increase">+</button>
+      </div>
     </div>
-    <%= f.submit "入力完了", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
   <% end %>
 </div>

--- a/app/views/foods/_edit_storage_modal.html.erb
+++ b/app/views/foods/_edit_storage_modal.html.erb
@@ -1,6 +1,9 @@
-<button class="btn grid flex-grow card bg-slate-50 rounded-box place-items-center" onclick="storage_modal.showModal()">
-  <%= t("activerecord.attributes.food.storages.#{@food.storage}")%>
+<button class="btn card bg-slate-50 rounded-box flex flex-row justify-between items-center w-full min-w-40" onclick="storage_modal.showModal()">
+  <span></span>
+  <span><%= t("activerecord.attributes.food.storages.#{@food.storage}")%></span>
+  <span>&gt;</span>
 </button>
+
 <dialog id="storage_modal" class="modal">
   <div class="modal-box">
     <h3 class="font-bold text-lg mb-3">保存場所</h3>
@@ -11,7 +14,7 @@
       <div class='flex items-center mx-auto max-w-xs'>
         <%= f.select :storage, Food.storages.keys.map { |key| [I18n.t("activerecord.attributes.food.storages.#{key}"), key] }, { selected: Food.storages.keys.first }, class:"mx-auto text-center" %>
       </div>
-      <%= f.submit "入力完了", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
+      <%= f.submit "変更する", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
     <% end %>
   </div>
 </dialog>

--- a/app/views/foods/_edit_storage_modal.html.erb
+++ b/app/views/foods/_edit_storage_modal.html.erb
@@ -1,4 +1,4 @@
-<button class="btn grid flex-grow max-w-96 card bg-base-200 rounded-box place-items-center" onclick="storage_modal.showModal()">
+<button class="btn grid flex-grow card bg-slate-50 rounded-box place-items-center" onclick="storage_modal.showModal()">
   <%= t("activerecord.attributes.food.storages.#{@food.storage}")%>
 </button>
 <dialog id="storage_modal" class="modal">

--- a/app/views/foods/_edit_storage_modal.html.erb
+++ b/app/views/foods/_edit_storage_modal.html.erb
@@ -1,0 +1,17 @@
+<button class="btn grid flex-grow max-w-96 card bg-base-200 rounded-box place-items-center" onclick="storage_modal.showModal()">
+  <%= t("activerecord.attributes.food.storages.#{@food.storage}")%>
+</button>
+<dialog id="storage_modal" class="modal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg mb-3">保存場所</h3>
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+    <%= form_with model: food, local:true do |f|%>
+      <div class='flex items-center mx-auto max-w-xs'>
+        <%= f.select :storage, Food.storages.keys.map { |key| [I18n.t("activerecord.attributes.food.storages.#{key}"), key] }, { selected: Food.storages.keys.first }, class:"mx-auto text-center" %>
+      </div>
+      <%= f.submit "入力完了", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
+    <% end %>
+  </div>
+</dialog>

--- a/app/views/foods/edit.html.erb
+++ b/app/views/foods/edit.html.erb
@@ -1,4 +1,0 @@
-<div class="container mx-auto text-center">
-  <h1 class="text-3xl font-bold text-center my-5">編集</h1>
-  <%= render 'form' %>
-</div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -1,28 +1,30 @@
 <div class="container mx-auto text-center">
-  <h1 class="text-3xl font-bold text-center my-5">食材詳細</h1>
+  <h1 class="text-3xl font-bold my-5">食材詳細</h1>
   <div class='my-5'>
-    <div class="flex flex-row justify-center">
-      <div class="px-10">
-        <div class="h-32 p-5 card bg-base-200 rounded-box place-items-center"><%= image_tag 'nophoto.jpg', size: "100x100"%></div>
-      </div>
-      <%= render partial: 'edit_name_modal', locals: { food: @food } %>
+    <div class=" justify-center">
+        <div class="h-32 p-5 card bg-slate-50 rounded-box items-center">
+          <%= image_tag 'nophoto.jpg', size: "100x100"%>
+        </div>
     </div>
   </div>
 
   <div class="flex flex-row justify-center">
-    <div class="p-5 text-center font-semibold">
-      <p>消費期限</p>
-      <%= render partial: 'edit_expiration_modal', locals: { food: @food } %>
+    <div class="grid flex-grow max-w-96 font-semibold p-5">
+      <p>食材名</p>
+      <%= render partial: 'edit_name_modal', locals: { food: @food } %>
     </div>
-
-    <div class="grid flex-grow max-w-96 text-center font-semibold p-5">
+    <div class="grid flex-grow max-w-96 font-semibold p-5">
       <p>在庫数</p>
       <%= render partial: 'edit_quantity_modal', locals: { food: @food } %>
     </div>
   </div>
 
   <div class="flex flex-row justify-center">
-    <div class="grid flex-grow max-w-96 text-center font-semibold p-5">
+    <div class="grid flex-grow max-w-96 font-semibold p-5">
+      <p>消費期限</p>
+      <%= render partial: 'edit_expiration_modal', locals: { food: @food } %>
+    </div>
+    <div class="grid flex-grow max-w-96 font-semibold p-5">
       <p>保存場所</p>
       <%= render partial: 'edit_storage_modal', locals: { food: @food } %>
     </div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -27,6 +27,5 @@
       <%= render partial: 'edit_storage_modal', locals: { food: @food } %>
     </div>
   </div>
-  <%= link_to t('foods.edit'), edit_food_path(@food), class: "btn btn-outline btn-success btn-xs sm:btn-sm md:btn-md"%>
   <%= link_to t('foods.destroy'), food_path(@food), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-xs sm:btn-sm md:btn-md"%>
 </div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -5,7 +5,7 @@
       <div class="px-10">
         <div class="h-32 p-5 card bg-base-200 rounded-box place-items-center"><%= image_tag 'nophoto.jpg', size: "100x100"%></div>
       </div>
-      <div class="grid flex-grow h-32 max-w-96 card bg-base-200 rounded-box place-items-center font-semibold"><%= @food.name %></div>
+      <%= render partial: 'edit_name_modal', locals: { food: @food } %>
     </div>
   </div>
 
@@ -16,11 +16,10 @@
         <%= @food.expiration_date %>
       </div>
     </div>
+
     <div class="grid flex-grow max-w-96 text-center font-semibold p-5">
       <p>在庫数</p>
-      <div class="card bg-base-200 rounded-box place-items-center p-5">
-        <%= @food.quantity %>
-      </div>
+      <%= render partial: 'edit_quantity_modal', locals: { food: @food } %>
     </div>
   </div>
 

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -12,9 +12,7 @@
   <div class="flex flex-row justify-center">
     <div class="p-5 text-center font-semibold">
       <p>消費期限</p>
-      <div class="card bg-base-200 rounded-box place-items-center p-5 min-w-36">
-        <%= @food.expiration_date %>
-      </div>
+      <%= render partial: 'edit_expiration_modal', locals: { food: @food } %>
     </div>
 
     <div class="grid flex-grow max-w-96 text-center font-semibold p-5">
@@ -24,17 +22,9 @@
   </div>
 
   <div class="flex flex-row justify-center">
-    <div class="p-5 text-center font-semibold">
-      <p>数量</p>
-      <div class="card bg-base-200 rounded-box place-items-center p-5 min-w-36">
-        <%= @food.quantity%>
-      </div>
-    </div>
     <div class="grid flex-grow max-w-96 text-center font-semibold p-5">
       <p>保存場所</p>
-      <div class="card bg-base-200 rounded-box place-items-center p-5">
-        <%= t("activerecord.attributes.food.storages.#{@food.storage}")%>
-      </div>
+      <%= render partial: 'edit_storage_modal', locals: { food: @food } %>
     </div>
   </div>
   <%= link_to t('foods.edit'), edit_food_path(@food), class: "btn btn-outline btn-success btn-xs sm:btn-sm md:btn-md"%>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -29,5 +29,5 @@
       <%= render partial: 'edit_storage_modal', locals: { food: @food } %>
     </div>
   </div>
-  <%= link_to t('foods.destroy'), food_path(@food), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-xs sm:btn-sm md:btn-md"%>
+  <%= link_to t('foods.destroy'), food_path(@food), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-md "%>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class='h-full'>
   <head>
     <title>pantry_chef_notifier_app</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -11,13 +11,17 @@
   </head>
 
   <body class='bg-linen'>
-    <% if user_signed_in? %>
-      <%= render 'shared/header' %>
-    <% else %>
-      <%= render 'shared/before_login_header' %>
-    <% end %>
-    <%= render 'shared/flash_message' %>
-    <%= yield %>
-    <%= render 'shared/footer' %>
+    <div class='flex flex-col min-h-screen'>
+      <% if user_signed_in? %>
+        <%= render 'shared/header' %>
+      <% else %>
+        <%= render 'shared/before_login_header' %>
+      <% end %>
+      <%= render 'shared/flash_message' %>
+      <div class='flex-grow'>
+        <%= yield %>
+      </div>
+      <%= render 'shared/footer' %>
+    </div>
   </body>
 </html>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -33,7 +33,7 @@ ja:
     logout: ログアウト
   foods:
     edit: 編集
-    destroy: 削除
+    destroy: 使いきった
 
 
 


### PR DESCRIPTION
実装内容
フロント
- [x] 詳細画面
  - [x] モーダル
    - [x] 名前の変更画面がモーダルで表示されている
    - [x] 期限の変更画面がモーダルで表示されている
    - [x] 在庫数の変更画面がモーダルで表示されている
      - [x] JSを使用して-と+で表示 
    - [x] 保存場所の変更画面がモーダルで表示されている
  - [x] 編集画面へのlinkを削除

バック
  - [x] 編集後に詳細画面に遷移するように変更
  - [x] 編集後にフラッシュメッセージが出ないように修正