### PR TITLE
食材に画像を登録する機能 #60 close

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,9 @@ gem 'rakuten_web_service'
 gem 'ransack'
 
 gem 'kaminari'
+# image_uploader
+gem 'carrierwave'
+gem 'mini_magick'
 
 group :development, :test do
   # Debugging tools

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,9 @@ gem 'kaminari'
 gem 'carrierwave'
 gem 'mini_magick'
 
+gem "aws-sdk-s3", require: false
+gem 'fog-aws'
+
 group :development, :test do
   # Debugging tools
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,22 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.944.0)
+    aws-sdk-core (3.197.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.84.0)
+      aws-sdk-core (~> 3, >= 3.197.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.152.3)
+      aws-sdk-core (~> 3, >= 3.197.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.8)
@@ -135,6 +151,7 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
+    excon (0.110.0)
     execjs (2.9.1)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -153,8 +170,24 @@ GEM
     ffi (1.17.0-x86-linux-gnu)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    fog-aws (3.22.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+    fog-core (2.4.0)
+      builder
+      excon (~> 0.71)
+      formatador (>= 0.2, < 2.0)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.4)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
+    formatador (1.1.0)
     fuubar (2.5.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
@@ -173,6 +206,7 @@ GEM
     jbuilder (2.12.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
     json (2.7.2)
@@ -209,12 +243,16 @@ GEM
     meta-tags (2.21.0)
       actionpack (>= 6.0.0, < 7.2)
     method_source (1.1.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0604)
     mini_magick (4.13.1)
     mini_mime (1.1.5)
     mini_racer (0.12.0)
       libv8-node (~> 21.7.2.0)
     minitest (5.22.3)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mutex_m (0.2.0)
@@ -466,6 +504,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  aws-sdk-s3
   bootsnap
   bullet
   capybara
@@ -477,6 +516,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  fog-aws
   font-awesome-rails
   fuubar
   jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (3.0.7)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     choice (0.2.0)
     chronic (0.10.2)
     coderay (1.1.3)
@@ -140,6 +147,12 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     font-awesome-rails (4.7.0.8)
       railties (>= 3.2, < 8.0)
     fuubar (2.5.1)
@@ -150,6 +163,9 @@ GEM
     hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.13.1)
       rdoc (>= 4.0.0)
@@ -193,6 +209,7 @@ GEM
     meta-tags (2.21.0)
       actionpack (>= 6.0.0, < 7.2)
     method_source (1.1.0)
+    mini_magick (4.13.1)
     mini_mime (1.1.5)
     mini_racer (0.12.0)
       libv8-node (~> 21.7.2.0)
@@ -377,6 +394,8 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.1)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     seed-fu (2.3.9)
       activerecord (>= 3.1)
@@ -399,6 +418,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.2)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -449,6 +469,7 @@ DEPENDENCIES
   bootsnap
   bullet
   capybara
+  carrierwave
   cssbundling-rails
   debug
   devise
@@ -463,6 +484,7 @@ DEPENDENCIES
   kaminari
   line-bot-api
   meta-tags
+  mini_magick
   mini_racer
   omniauth
   omniauth-line

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -52,7 +52,7 @@ class FoodsController < ApplicationController
   private
 
   def food_params
-    params.require(:food).permit(:id, :name, :quantity, :expiration_date, :storage)
+    params.require(:food).permit(:id, :name, :quantity, :expiration_date, :storage, :food_image, :food_image_cache)
   end
 
   def set_q

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -2,6 +2,7 @@
 
 class Food < ApplicationRecord
   belongs_to :user
+  mount_uploader :food_image, FoodImageUploader
   enum storage: { refrigerator: 0, freezer: 1, others: 2 }
 
   validates :name, presence: true

--- a/app/uploaders/food_image_uploader.rb
+++ b/app/uploaders/food_image_uploader.rb
@@ -4,7 +4,12 @@ class FoodImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
+  if Rails.env.production?
+    storage :fog # 本番環境ではfogを使用
+  else
+    storage :file # 開発環境とテスト環境ではfileを使用
+  end
+
   # storage :fog
 
   # Override the directory where uploaded files will be stored.

--- a/app/uploaders/food_image_uploader.rb
+++ b/app/uploaders/food_image_uploader.rb
@@ -1,0 +1,44 @@
+class FoodImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  def default_url
+    'nophoto'
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/uploaders/food_image_uploader.rb
+++ b/app/uploaders/food_image_uploader.rb
@@ -20,7 +20,7 @@ class FoodImageUploader < CarrierWave::Uploader::Base
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url
-    'nophoto'
+    'nophoto.jpg'
   end
 
   # Process files as they are uploaded:

--- a/app/views/foods/_edit_image_modal.erb
+++ b/app/views/foods/_edit_image_modal.erb
@@ -1,0 +1,19 @@
+<button class="h-62 p-5 card mx-auto" onclick="image_modal.showModal()">
+  <span><%= image_tag food.food_image_url, class: "w-36 h-36 sm:w-72 sm:h-72" %></span>
+</button>
+
+<dialog id="image_modal" class="modal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg mb-3">写真を変更します</h3>
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+    <%= form_with model: food, local:true do |f|%>
+      <div class='flex items-center mx-auto max-w-xs'>
+        <%= f.file_field :food_image, class: "file-input file-input-bordered w-full max-w-xs", accept: 'image/*' %>
+        <%= f.hidden_field :food_image_cache %>
+      </div>
+      <%= f.submit "変更する", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
+    <% end %>
+  </div>
+</dialog>

--- a/app/views/foods/_form.html.erb
+++ b/app/views/foods/_form.html.erb
@@ -1,33 +1,38 @@
 
 <%= form_with model: @food, local:true do |f|%>
   <%= render 'shared/error_messages', object: f.object %>
-  <div class="field my-11">
+  <div class="field mb-8">
     <div class='input input-bordered flex items-center gap-2 mx-auto max-w-xs'>
       <%= f.label :name %>
       <%= f.text_field :name, class:"text-area mx-auto text-center ", placeholder: "食材名" %>
     </div>
   </div>
 
-  <div class="field my-11">
+  <div class="field mb-8">
     <div class='input input-bordered flex items-center gap-2 mx-auto max-w-xs'>
       <%= f.label :quantity %>
       <%= f.number_field :quantity, class:"mx-auto text-center", placeholder: "0", min: 0 %>
     </div>
   </div>
 
-  <div class="field my-11">
+  <div class="field mb-8">
     <div class='input input-bordered flex items-center gap-2 mx-auto max-w-xs'>
       <%= f.label :expiration_date %>
       <%= f.date_field :expiration_date, class:"mx-auto text-center"%>
     </div>
   </div>
 
-  <div class="field my-11">
+  <div class="field mb-8">
     <div class='input input-bordered flex items-center gap-2 mx-auto max-w-xs'>
       <%= f.label :storage %>
       <%= f.select :storage, Food.storages.keys.map { |key| [I18n.t("activerecord.attributes.food.storages.#{key}"), key] }, { selected: Food.storages.keys.first }, class:"mx-auto text-center" %>
     </div>
   </div>
 
-  <%= f.submit "登録する", disable_with: '登録中...', class:"btn btn-outline btn-success"%>
+  <div class="mb-8">
+    <%= f.file_field :food_image, class: "file-input file-input-bordered w-full max-w-xs", accept: 'image/*' %>
+    <%= f.hidden_field :food_image_cache %>
+  </div>
+
+  <%= f.submit "登録する", disable_with: '登録中...', class:"btn btn-outline btn-success mb-5"%>
 <% end %>

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -32,7 +32,7 @@
           <div class="flex justify-center">
             <div class="card w-80 bg-base-100 shadow-xl">
               <figure class="p-5 bg-primary-content">
-                <%= image_tag 'nophoto.jpg', size: "150x150" %>
+                <%= image_tag food.food_image_url, class: "w-36 h-36" %>
               </figure>
               <div class="card-body items-center text-center">
                 <h2 class="card-title"><%= food.name %></h2>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -1,12 +1,10 @@
 <div class="container mx-auto text-center">
-  <h1 class="text-3xl font-bold my-5">食材詳細</h1>
-  <div class='my-5'>
+  <h1 class="text-3xl font-bold mt-5">食材詳細</h1>
     <div class=" justify-center">
-        <div class="h-32 p-5 card bg-slate-50 rounded-box items-center">
-          <%= image_tag 'nophoto.jpg', size: "100x100"%>
-        </div>
+      <div class="h-62 p-5 card rounded-box items-center">
+        <%= image_tag @food.food_image_url, class: "w-36 h-36 sm:w-72 sm:h-72" %>
+      </div>
     </div>
-  </div>
 
   <div class="flex flex-row justify-center">
     <div class="grid flex-grow max-w-96 font-semibold p-5">
@@ -29,5 +27,5 @@
       <%= render partial: 'edit_storage_modal', locals: { food: @food } %>
     </div>
   </div>
-  <%= link_to t('foods.destroy'), food_path(@food), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-md "%>
+  <%= link_to t('foods.destroy'), food_path(@food), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-md mb-5"%>
 </div>

--- a/app/views/foods/show.html.erb
+++ b/app/views/foods/show.html.erb
@@ -1,9 +1,7 @@
 <div class="container mx-auto text-center">
   <h1 class="text-3xl font-bold mt-5">食材詳細</h1>
     <div class=" justify-center">
-      <div class="h-62 p-5 card rounded-box items-center">
-        <%= image_tag @food.food_image_url, class: "w-36 h-36 sm:w-72 sm:h-72" %>
-      </div>
+      <%= render partial: 'edit_image_modal', locals: { food: @food } %>
     </div>
 
   <div class="flex flex-row justify-center">

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# exit on error
+set -o errexit
+
+bundle install
+bundle exec rake assets:precompile
+bundle exec rake assets:clean
+# bundle exec rake db:migrate
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# exit on error
-set -o errexit
-
-bundle install
-bundle exec rake assets:precompile
-bundle exec rake assets:clean
-# bundle exec rake db:migrate
-DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,16 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'pantrychefnotifier '
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1',
+      path_style: true
+    }
+end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,13 +6,12 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+amazon:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: ap-northeast-1 
+  bucket: <%= ENV['AWS_BUCKET_NAME'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/db/migrate/20240617004827_add_food_image_to_foods.rb
+++ b/db/migrate/20240617004827_add_food_image_to_foods.rb
@@ -1,0 +1,5 @@
+class AddFoodImageToFoods < ActiveRecord::Migration[7.1]
+  def change
+    add_column :foods, :food_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_16_045153) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_004827) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_16_045153) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "storage", default: 0, null: false
+    t.string "food_image"
     t.index ["user_id"], name: "index_foods_on_user_id"
   end
 


### PR DESCRIPTION
実装内容
フロント
- [x]  新規登録フォームにFile Inputフォームを追加
- [x] 食材の画像が登録されている場合は登録された画像を表示
- [x] 食材の画像が登録されていない場合はデフォルトの画像を表示
- [x] 詳細画面で画像を押すと、モーダルで編集フォームが表示される。

バック
- [x] 画像をアップロードするためのgem 'carrierwave'とgem 'mini_magick'を追加
- [x] 画像登録機能を実装
- [x] 詳細画面での画像の編集機能を追加
- [x] aws s3との連携のためgem "aws-sdk-s3", require: falseとgem 'fog-aws'を追加
- [x] aws s3との連携を行うために各種設定ファイルを変更