### PR TITLE
InvalidBucketNameが発生していたため半角が空いている場所を修正 #80 close

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,7 +5,7 @@ require 'carrierwave/storage/fog'
 CarrierWave.configure do |config|
     config.storage :fog
     config.fog_provider = 'fog/aws'
-    config.fog_directory  = 'pantrychefnotifier '
+    config.fog_directory  = 'pantrychefnotifier'
     config.fog_credentials = {
       provider: 'AWS',
       aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],


### PR DESCRIPTION
実装内容
InvalidBucketNameが発生していたため半角が空いている場所を修正