### PR TITLE
パスワードを忘れた場合のメール送信処理 #12 close

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :development do
   gem 'rails-erd'
   gem 'spring'
   gem 'web-console'
+  gem 'letter_opener_web'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
+    childprocess (5.0.0)
     choice (0.2.0)
     chronic (0.10.2)
     coderay (1.1.3)
@@ -224,6 +225,16 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     libv8-node (21.7.2.0)
     libv8-node (21.7.2.0-aarch64-linux)
     libv8-node (21.7.2.0-arm64-darwin)
@@ -522,6 +533,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kaminari
+  letter_opener_web
   line-bot-api
   meta-tags
   mini_magick

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,12 @@
-<p>Hello <%= @resource.email %>!</p>
+<%# パスワードリセットメール本文 %>
+<p><%= @resource.email %>様</p>
+<p>パスワード再設定の申請を受け付けました。</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードの再設定をご希望の場合は、以下URLをクリックし<br>新しいパスワードをご登録ください。</p>
+<p>※パスワードリセットの申請に心当たりがない場合は、以降の対応は不要となります。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>▼パスワードの再設定URL</p>
+<p><%= link_to 'パスワードを再設定する', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p>※リンクの有効期限は6時間です。</p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>本メールに心当たりが無い場合は破棄をお願いいたします。<br>送信専用メールアドレスのため、直接の返信はできません。</p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,25 +1,32 @@
-<h2>Change your password</h2>
+<div class="container mx-auto text-center">
+  <h2 class="my-11 text-3xl font-bold">パスワードを再設定</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "users/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
+    <div class="field my-11">
+      <label class="input input-bordered flex items-center gap-2 mx-auto max-w-xs">
+        <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4 opacity-70">
+          <path fill-rule="evenodd" d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z" clip-rule="evenodd" />
+        </svg>
+        <%= f.password_field :password, class: "grow", autofocus: true, placeholder: "新しいパスワード(6文字以下)", autocomplete: "新しいパスワード" %>
+      </label>
+    </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="field">
+      <label class="input input-bordered flex items-center gap-2 mx-auto max-w-xs">
+          <svg viewBox="0 0 16 16" fill="currentColor" class="w-4 h-4 opacity-70">
+            <path fill-rule="evenodd" d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z" clip-rule="evenodd" />
+          </svg>
+        <%= f.password_field :password_confirmation, placeholder: "新しいパスワード(確認)", autocomplete: "new-password" %>
+      </label>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
+    <div class="actions">
+      <%= f.submit "パスワード変更", class:"btn btn-outline my-3"  %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "users/shared/links" %>
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,16 +1,21 @@
-<h2>Forgot your password?</h2>
+<div class="container mx-auto text-center">
+  <h2 class="my-11 text-3xl font-bold">パスワードを忘れてしまった方へ</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= render "users/shared/error_messages", resource: resource %>
+    <div class="field my-11">
+      <label class="input input-bordered flex items-center gap-2 mx-auto max-w-xs">
+        <svg class="h-4 w-4 text-gray-500"  fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+        </svg>
+        <%= f.email_field :email, class: "grow", placeholder: "登録メールアドレスを入力", autofocus: true, autocomplete: "email" %>
+      </label>
+    </div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div class="actions">
+      <%= f.submit "再設定メールを送信する", class:"btn btn-outline my-3" %>
+    </div>
+  <% end %>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+  <%= render "users/shared/links" %>
+</div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -9,12 +9,12 @@
     <%= link_to "新規登録はこちら", new_registration_path(resource_name), class: 'link link-primary' %><br />
   </div>
 <% end %>
-<%# 6.18 パスワードを忘れた場合のメール送信処理がまだ実装できていないのでコメントアウト %>
-<%# if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%# <div class="mt-3"> %>
-    <%#= link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class: 'link link-primary'%><br />
-  <%# </div> %>
-<%# end %>
+
+<% if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <div class="mt-3">
+    <%= link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class: 'link link-primary'%><br />
+  </div>
+<% end %>
 
 <div class="w-full relative h-10">
   <div class="border-t border-aqua_island w-full text-center overflow-visible absolute top-1/2 left-0">
@@ -22,7 +22,6 @@
   </div>
   <p class="w-full text-center absolute top-[6px] left-0"><span class="bg-linen px-6">または</span></p>
 </div>
-
 <%# Deviseの設定でOmniAuthが有効かどうかをチェック %>
 <%- if devise_mapping.omniauthable? %>
   <div class="flex flex-col items-center justify-center mt-3">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,5 +77,9 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 
-  config.action_mailer.default_url_options = { protocol: 'https', host: 'トップページアドレス' }
+  # config.action_mailer.default_url_options = { protocol: 'https', host: 'トップページアドレス' }
+  host = 'localhost:3000'
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
+
+  config.action_mailer.delivery_method = :letter_opener_web
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,6 +74,20 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "pantry_chef_notifier_app_production"
 
   config.action_mailer.perform_caching = false
+  # 本番環境でのメール送信設定
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'https://pantry-chef-notifier.onrender.com'
+  config.action_mailer.default_url_options = { host: host }
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.gmail.com',
+    port:                 587,
+    domain:               'gmail.com',
+    user_name:            ENV['SMTP_USER_NAME'],
+    password:             ENV['SMTP_PASSWORD'],
+    authentication:       'plain',
+    enable_starttls_auto: true
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'pantry-chef-notifier@onrender.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,4 +35,8 @@ Rails.application.routes.draw do
 
   # rakuten
   get 'search', to: 'rakuten_recipes#search'
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end


### PR DESCRIPTION
### 実装内容
- [x]  ログインページにパスワードリセットの申請ページへのリンクを作成
  - [x]  デフォルトのパスワードリセットの申請ページを変更
    - [x]  メールアドレスの入力フォームがあること
    - [x]  送信ボタンがあること
- [x]  パスワードリセットメールが送信されること
  - [x]  gem 'letter_opener_web' を導入(開発環境で使用)
- [x]  メールからパスワード再設定用のページに遷移すること
  - [x]  デフォルトのパスワード再設定用のページを変更
    - [x]  パスワードの入力フォームがあること
    - [x]  パスワード確認の入力フォームがあること
    - [x]  送信ボタンがあること
    - [x]  送信ボタンを押すと、ログイン画面に遷移すること
- [x]  再設定したパスワードでログインできること
- [x] 本番環境でのメールサーバーの設定
  - [x] 環境変数の設定
  - [x] 本番環境のメールサーバーの設定を追記
- [x] 本番環境での挙動を確認
### 補足
開発環境での処理は確認ずみ。
本番環境では未確認なので確認後コメントする。
