### PR TITLE
Line上での食材登録機能の実装 #79 close

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -33,9 +33,9 @@ class LineBotController < ApplicationController
   end
   # ユーザー検索
   def find_user(event)
-    line_id = event['source']['userId']  # eventはメソッドのスコープ外で定義されていると仮定する
+    line_id = event['source']['userId']
     user = User.find_by(uid: line_id)
-    return user  # ユーザーが見つかった場合にそのユーザーを返す
+    return user
   end
   # メッセージ処理
   def main_event(event, user)
@@ -45,99 +45,117 @@ class LineBotController < ApplicationController
       when Line::Bot::Event::MessageType::Text
         message = create_message(event.message['text'], user)
         client.reply_message(event['replyToken'], message)
+      when Line::Bot::Event::MessageType::Image
+        handle_image_message(event, user)
       end
     end
   end
   # LineBotからユーザーへのメッセージ生成
   def create_message(text, user)
-    # user.update(status: 'idle')
     case text
     when '食材リスト'
-      food_list(send_foods_item(user), text)
+      { type: 'text', text: send_foods_item(user) }
     when '消費期限'
-      food_list(send_food_limits(user), text)
+      { type: 'text', text: send_food_limits(user) }
     when 'レシピ検索'
       recipe_branch(user)
     when '食材登録'
-      case user.status
-      when 'idle'
+      if user.status == 'idle'
         user.update(status: 'waiting_add_food_name')
         { type: 'text', text: '登録する食材名を入力してください' }
       end
     else
-      if user.status == 'waiting_for_recipe'
-        recipe_branch(user, text)
-      elsif  user.status == 'waiting_add_food_name'
-        temp_food = user.line_messages.create(temp_name: text)
-        user.update(status: 'waiting_add_food_quantity')
-        { type: 'text', text: '在庫数を数字で入力してください。' }
-      elsif user.status == 'waiting_add_food_quantity'
-
-        temp_food = user.line_messages.last
-        temp_food.update(temp_quantity: text)
-        user.update(status: 'waiting_add_food_expiration')
-        { type: 'text', text: '消費期限を入力してください。例）2024-07-25' }
-
-      elsif user.status == 'waiting_add_food_expiration'
-
-        user.update(status: 'waiting_add_food_storage')
-        temp_food = user.line_messages.last
-        temp_food.update(temp_expiration_date: text)
-        { type: 'text', text: '保存場所を数字で入力してください。0: 冷蔵庫 1: 冷凍庫 2: その他' }
-
-      elsif user.status == 'waiting_add_food_storage'
-
-        user.update(status: 'waiting_add_food_image')
-        temp_food = user.line_messages.last
-        temp_food.update(temp_storage: text)
-        { type: 'text', text: '画像を送信してください' }
-
-      elsif user.status == 'waiting_add_food_image'
-        temp_food = user.line_messages.last
-        user.update(status: 'idle')
-        food = Food.new(
-                name: temp_food.temp_name,
-                quantity: temp_food.temp_quantity,
-                expiration_date: temp_food.temp_expiration_date,
-                storage: temp_food.temp_storage.to_i,
-                user_id: user.id
-              )
-        if food.save
-          saved_food = Food.find_by(name: temp_food.temp_name, user_id: user.id)
-          response = "以下の食材が保存されました。\n\n食材名: #{saved_food.name}\n在庫数: #{saved_food.quantity}\n消費期限: #{saved_food.expiration_date}\n保存場所: #{saved_food.storage}"
-        else
-          response = 'エラーが発生しました。正しく入力してください。'
-        end
-        { type: 'text', text: response }
-      else
-        user.update(status: 'idle')
-        { type: 'text', text: 'エラーが発生しました。正しく入力してください。' }
-      end
+      handle_text_message(text, user)
     end
   end
+# 食材画像の処理
+  def handle_image_message(event, user)
+    if user.status == 'waiting_add_food_image'
+      response = client.get_message_content(event.message['id'])
+      file = Tempfile.new(['line_image', '.jpg'])
+      file.binmode
+      file.write(response.body)
+      file.rewind
+
+      temp_food = user.line_messages.last
+      food = Food.new(
+        name: temp_food.temp_name,
+        quantity: temp_food.temp_quantity,
+        expiration_date: temp_food.temp_expiration_date,
+        storage: temp_food.temp_storage.to_i,
+        user_id: user.id,
+        food_image: file
+      )
+
+      file.close
+      file.unlink
+
+      if food.save
+        response_text = "以下の食材が保存されました。\n\n食材名: #{food.name}\n在庫数: #{food.quantity}\n消費期限: #{food.expiration_date}\n保存場所: #{food.storage}"
+      else
+        response_text = 'エラーが発生しました。正しく入力してください。'
+      end
+      user.update(status: 'idle')
+      client.reply_message(event['replyToken'], { type: 'text', text: response_text })
+    else
+      client.reply_message(event['replyToken'], { type: 'text', text: 'エラーが発生しました。正しく入力してください。' })
+      user.update(status: 'idle')
+    end
+  end
+# 食材登録の対話機能の条件分岐（食材名、在庫数、消費期限、保存場所）
+  def handle_text_message(text, user)
+    case user.status
+    when 'waiting_for_recipe'
+      recipe_branch(user, text)
+    when 'waiting_add_food_name'
+      temp_food = user.line_messages.create(temp_name: text)
+      user.update(status: 'waiting_add_food_quantity')
+      { type: 'text', text: '在庫数を数字で入力してください。' }
+    when 'waiting_add_food_quantity'
+      temp_food = user.line_messages.last
+      temp_food.update(temp_quantity: text)
+      user.update(status: 'waiting_add_food_expiration')
+      { type: 'text', text: '消費期限を入力してください。例）2024-07-25' }
+    when 'waiting_add_food_expiration'
+      temp_food = user.line_messages.last
+      temp_food.update(temp_expiration_date: text)
+      user.update(status: 'waiting_add_food_storage')
+      { type: 'text', text: '保存場所を数字で入力してください。0: 冷蔵庫 1: 冷凍庫 2: その他' }
+    when 'waiting_add_food_storage'
+      temp_food = user.line_messages.last
+      temp_food.update(temp_storage: text)
+      user.update(status: 'waiting_add_food_image')
+      { type: 'text', text: '画像を送信してください' }
+    else
+      user.update(status: 'idle')
+      { type: 'text', text: 'エラーが発生しました。正しく入力してください。' }
+    end
+  end
+
   # 食材リストの取得とメッセージ生成
   def send_foods_item(user)
-    food_items =  Food.where(user_id: user.id)
-    if food_items != []
+    food_items = Food.where(user_id: user.id)
+    if food_items.any?
       names = food_items.map(&:name)
       quantity = food_items.map(&:quantity)
       result = names.zip(quantity).map { |name, qty| "#{name} : 在庫数#{qty}" }.join("\n")
-      response = "以下の食材があります。\n\n#{result}"
+      "以下の食材があります。\n\n#{result}"
     else
-      response = '食材が登録されていません。'
+      '食材が登録されていません。'
     end
   end
+
   # 期限が近づいている食材の取得とメッセージの生成
   def send_food_limits(user)
     limit_second_days = Date.today..Time.now.end_of_day + 2.days
-    limit_foods =  Food.where(user_id: user.id).where(expiration_date: limit_second_days)
-    if limit_foods != []
+    limit_foods = Food.where(user_id: user.id, expiration_date: limit_second_days)
+    if limit_foods.any?
       names = limit_foods.map(&:name)
       expiration_dates = limit_foods.map(&:expiration_date)
       result = names.zip(expiration_dates).map { |name, expiration_date| "#{name} : 消費期限#{expiration_date}" }.join("\n")
-      response = "以下の食材の消費期限が近づいています（二日以内）。\n早めに消費することをオススメします。\n\n#{result}"
+      "以下の食材の消費期限が近づいています（二日以内）。\n早めに消費することをオススメします。\n\n#{result}"
     else
-      response = '二日以内が期限の食材はありません。'
+      '二日以内が期限の食材はありません。'
     end
   end
   # レシピ検索の対話機能の条件分離
@@ -162,9 +180,4 @@ class LineBotController < ApplicationController
       end
     end
   end
-
-  # 食材の画登録処理
-  # def
-
-  # end
 end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -69,24 +69,35 @@ class LineBotController < ApplicationController
         recipe_branch(user, text)
       elsif  user.status == 'waiting_add_food_name'
         user.update(status: 'waiting_add_food_quantity')
-
+        user.line_messages.create(message_content: text)
+        { type: 'text', text: user.line_messages.first.message_content }
         { type: 'text', text: '在庫数を入力してください' }
       elsif user.status == 'waiting_add_food_quantity'
         user.update(status: 'waiting_add_food_expiration')
-
-        { type: 'text', text: '消費期限を入力してください' }
+        user.line_messages.create(message_content: text)
+        { type: 'text', text: '消費期限を入力してください。例）2024-07-25' }
       elsif user.status == 'waiting_add_food_expiration'
         user.update(status: 'waiting_add_food_storage')
-
-        { type: 'text', text: '保存場所を入力してください' }
+        user.line_messages.create(message_content: text)
+        { type: 'text', text: '保存場所を数字で入力してください。0: 冷蔵庫 1: 冷凍庫 2: その他' }
       elsif user.status == 'waiting_add_food_storage'
         user.update(status: 'waiting_add_food_image')
-
+        # まだ未実装
+        user.line_messages.create(message_content: text)
         { type: 'text', text: '画像を送信してください' }
       elsif user.status == 'waiting_add_food_image'
         user.update(status: 'idle')
-
+        user.line_messages.create(message_content: text)
         { type: 'text', text: '食材を登録しました' }
+        food_name = user.line_messages[-5].message_content
+        food_quantity = user.line_messages[-4].message_content
+        food_expiration = user.line_messages[-3].message_content
+        food_storage = user.line_messages[-2].message_content
+        # food_image = user.line_messages[-1].message_content
+        Food.create(name: food_name, quantity: food_quantity, expiration_date: food_expiration, storage: food_storage.to_i, user_id: user.id)
+        saved_food = Food.find_by(name: food_name, user_id: user.id)
+        response = "以下の食材が保存されました。\n\n食材名: #{saved_food.name}\n在庫数: #{saved_food.quantity}\n消費期限: #{saved_food.expiration_date}\n保存場所: #{saved_food.storage}"
+        { type: 'text', text: response }
       else
         user.update(status: 'idle')
         { type: 'text', text: 'エラー発生' }
@@ -140,4 +151,9 @@ class LineBotController < ApplicationController
       end
     end
   end
+
+  # 食材の画登録処理
+  # def
+
+  # end
 end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -55,39 +55,41 @@ class LineBotController < ApplicationController
       food_list(send_foods_item(user), text)
     when '消費期限'
       food_list(send_food_limits(user), text)
+
     when '食材登録'
       case user.status
       when 'idle' # ユーザーが何もしていない状態
         user.update(status: 'waiting_add_food_name')
-        { type: 'text', text: '食材名を入力してください' }
-      when 'waiting_add_food_name' # 食材名を入力待ち
-        user.update(status: 'waiting_add_food_quantity')
-        user.foods.create(name: text)
-        { type: 'text', text: '量を入力してください' }
-      when 'waiting_add_food_quantity' # 食材の量を入力待ち
-        user.update(status: 'waiting_add_food_expiration')
-        user.foods.last.update(quantity: text)
-        { type: 'text', text: '消費期限を入力してください' }
-      when 'waiting_add_food_expiration'# 食材の消費期限を入力待ち
-        user.update(status: 'waiting_add_food_storage')
-        user.foods.last.update(expiration_date: text)
-        { type: 'text', text: '保存場所を入力してください' }
-      when 'waiting_add_food_storage'# 食材の保存場所を入力待ち
-        user.update(status: 'waiting_add_food_image')
-        user.foods.last.update(storage: text)
-        { type: 'text', text: '画像を送信してください' }
-      when 'waiting_add_food_image'# 食材の画像を入力待ち
-        user.update(status: 'idle')
-        user.foods.last.update(image: params[:food_image])
-        { type: 'text', text: '食材を登録しました' }
+        { type: 'text', text: '登録する食材名を入力してください' }
       end
     when 'レシピ検索'
       recipe_branch(user)
     else
       if user.status == 'waiting_for_recipe'
         recipe_branch(user, text)
+      elsif  user.status == 'waiting_add_food_name'
+        user.update(status: 'waiting_add_food_quantity')
+
+        { type: 'text', text: '在庫数を入力してください' }
+      elsif user.status == 'waiting_add_food_quantity'
+        user.update(status: 'waiting_add_food_expiration')
+
+        { type: 'text', text: '消費期限を入力してください' }
+      elsif user.status == 'waiting_add_food_expiration'
+        user.update(status: 'waiting_add_food_storage')
+
+        { type: 'text', text: '保存場所を入力してください' }
+      elsif user.status == 'waiting_add_food_storage'
+        user.update(status: 'waiting_add_food_image')
+
+        { type: 'text', text: '画像を送信してください' }
+      elsif user.status == 'waiting_add_food_image'
+        user.update(status: 'idle')
+
+        { type: 'text', text: '食材を登録しました' }
       else
-        { type: 'text', text: text }
+        user.update(status: 'idle')
+        { type: 'text', text: 'エラー発生' }
       end
     end
   end

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -55,6 +55,32 @@ class LineBotController < ApplicationController
       food_list(send_foods_item(user), text)
     when '消費期限'
       food_list(send_food_limits(user), text)
+    when '食材登録'
+      case user.status
+      when 'idle' # ユーザーが何もしていない状態
+        user.update(status: 'waiting_add_food_name')
+        { type: 'text', text: '食材名を入力してください' }
+      when 'waiting_add_food_name' # 食材名を入力待ち
+        user.update(status: 'waiting_add_food_quantity')
+        user.foods.create(name: text)
+        { type: 'text', text: '量を入力してください' }
+      when 'waiting_add_food_quantity' # 食材の量を入力待ち
+        user.update(status: 'waiting_add_food_expiration')
+        user.foods.last.update(quantity: text)
+        { type: 'text', text: '消費期限を入力してください' }
+      when 'waiting_add_food_expiration'# 食材の消費期限を入力待ち
+        user.update(status: 'waiting_add_food_storage')
+        user.foods.last.update(expiration_date: text)
+        { type: 'text', text: '保存場所を入力してください' }
+      when 'waiting_add_food_storage'# 食材の保存場所を入力待ち
+        user.update(status: 'waiting_add_food_image')
+        user.foods.last.update(storage: text)
+        { type: 'text', text: '画像を送信してください' }
+      when 'waiting_add_food_image'# 食材の画像を入力待ち
+        user.update(status: 'idle')
+        user.foods.last.update(image: params[:food_image])
+        { type: 'text', text: '食材を登録しました' }
+      end
     when 'レシピ検索'
       recipe_branch(user)
     else

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -50,51 +50,49 @@ class LineBotController < ApplicationController
   end
   # LineBotからユーザーへのメッセージ生成
   def create_message(text, user)
+    # user.update(status: 'idle')
     case text
     when '食材リスト'
       food_list(send_foods_item(user), text)
     when '消費期限'
       food_list(send_food_limits(user), text)
-
     when '食材登録'
       case user.status
-      when 'idle' # ユーザーが何もしていない状態
+      when 'idle'
         user.update(status: 'waiting_add_food_name')
         { type: 'text', text: '登録する食材名を入力してください' }
       end
     when 'レシピ検索'
       recipe_branch(user)
     else
+
       if user.status == 'waiting_for_recipe'
         recipe_branch(user, text)
       elsif  user.status == 'waiting_add_food_name'
-        user.update(status: 'waiting_add_food_quantity')
-        user.line_messages.create(message_content: text)
-        { type: 'text', text: user.line_messages.first.message_content }
+
+        temp_food = user.line_messages.create(temp_name: text)
+        user.update(status: 'waiting_add_food_quantity', current_temp_food_id: temp_food.id)
         { type: 'text', text: '在庫数を入力してください' }
       elsif user.status == 'waiting_add_food_quantity'
+        temp_food = LineMessage.find(user.current_temp_food_id)
+        temp_food.update(temp_quantity: text)
         user.update(status: 'waiting_add_food_expiration')
         user.line_messages.create(message_content: text)
         { type: 'text', text: '消費期限を入力してください。例）2024-07-25' }
       elsif user.status == 'waiting_add_food_expiration'
         user.update(status: 'waiting_add_food_storage')
-        user.line_messages.create(message_content: text)
+        temp_food = LineMessage.find(user.current_temp_food_id)
+        temp_food.update(temp_expiration_date: text)
+
         { type: 'text', text: '保存場所を数字で入力してください。0: 冷蔵庫 1: 冷凍庫 2: その他' }
       elsif user.status == 'waiting_add_food_storage'
         user.update(status: 'waiting_add_food_image')
-        # まだ未実装
-        user.line_messages.create(message_content: text)
+        temp_food = LineMessage.find(user.current_temp_food_id)
+        temp_food.update(temp_storage: text)
         { type: 'text', text: '画像を送信してください' }
       elsif user.status == 'waiting_add_food_image'
         user.update(status: 'idle')
-        user.line_messages.create(message_content: text)
-        { type: 'text', text: '食材を登録しました' }
-        food_name = user.line_messages[-5].message_content
-        food_quantity = user.line_messages[-4].message_content
-        food_expiration = user.line_messages[-3].message_content
-        food_storage = user.line_messages[-2].message_content
-        # food_image = user.line_messages[-1].message_content
-        Food.create(name: food_name, quantity: food_quantity, expiration_date: food_expiration, storage: food_storage.to_i, user_id: user.id)
+        Food.create(name: temp_food.name, quantity: temp_food.quantity, expiration_date: temp_food.expiration_date, storage: temp_food.storage.to_i, user_id: user.id)
         saved_food = Food.find_by(name: food_name, user_id: user.id)
         response = "以下の食材が保存されました。\n\n食材名: #{saved_food.name}\n在庫数: #{saved_food.quantity}\n消費期限: #{saved_food.expiration_date}\n保存場所: #{saved_food.storage}"
         { type: 'text', text: response }

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -43,7 +43,7 @@ class LineBotController < ApplicationController
     when Line::Bot::Event::Message
       case event.type
       when Line::Bot::Event::MessageType::Text
-        message = create_message(event.message['text'], user)
+        message = create_message(event.message['text'], user, event)
         client.reply_message(event['replyToken'], message)
       when Line::Bot::Event::MessageType::Image
         handle_image_message(event, user)
@@ -51,8 +51,7 @@ class LineBotController < ApplicationController
     end
   end
   # LineBotからユーザーへのメッセージ生成
-  def create_message(text, user)
-    # user.update(status: 'idle')
+  def create_message(text, user, event)
     case text
     when '食材リスト'
       { type: 'text', text: send_foods_item(user) }
@@ -60,10 +59,15 @@ class LineBotController < ApplicationController
       { type: 'text', text: send_food_limits(user) }
     when 'レシピ検索'
       recipe_branch(user)
-    when '食材登録'
+    when '食材の登録'
       if user.status == 'idle'
         user.update(status: 'waiting_add_food_name')
         { type: 'text', text: '登録する食材名を入力してください' }
+      end
+    when 'スキップ'
+      if user.status == 'waiting_add_food_image'
+        user.update(status: 'idle')
+        save_food_without_image(user, event)
       end
     else
       handle_text_message(text, user)
@@ -82,44 +86,7 @@ class LineBotController < ApplicationController
       respond_with_error(event)
     end
   end
-# messageIDから画像ファイルを一時保存
-  def fetch_image_file(message_id)
-    response = client.get_message_content(message_id)
-    file = Tempfile.new(['line_image', '.jpg'])
-    file.binmode
-    file.write(response.body)
-    file.rewind
-    file
-  end
 
-# Foodオブジェクトの作成
-  def save_food_with_image(file, user, event)
-    temp_food = user.line_messages.last
-    food = Food.new(
-      name: temp_food.temp_name,
-      quantity: temp_food.temp_quantity,
-      expiration_date: temp_food.temp_expiration_date,
-      storage: temp_food.temp_storage.to_i,
-      user_id: user.id,
-      food_image: file
-    )
-
-    file.close
-    file.unlink
-
-    if food.save
-      response_text = "以下の食材が保存されました。\n\n食材名: #{food.name}\n在庫数: #{food.quantity}\n消費期限: #{food.expiration_date}\n保存場所: #{food.storage}"
-    else
-      response_text = 'エラーが発生しました。正しく入力してください。'
-    end
-    user.update(status: 'idle')
-    client.reply_message(event['replyToken'], { type: 'text', text: response_text })
-  end
-# エラーの場合の処理
-  def respond_with_error(event)
-    client.reply_message(event['replyToken'], { type: 'text', text: 'エラーが発生しました。正しく入力してください。' })
-    user.update(status: 'idle')
-  end
 # 食材登録の対話機能の条件分岐（食材名、在庫数、消費期限、保存場所）
   def handle_text_message(text, user)
     case user.status
@@ -143,11 +110,71 @@ class LineBotController < ApplicationController
       temp_food = user.line_messages.last
       temp_food.update(temp_storage: text)
       user.update(status: 'waiting_add_food_image')
-      { type: 'text', text: '画像を送信してください' }
+      { type: 'text', text: '画像を送信してください。画像を保存しない場合は「スキップ」と入力してください。' }
     else
       user.update(status: 'idle')
       { type: 'text', text: 'エラーが発生しました。正しく入力してください。' }
     end
+  end
+
+  # messageIDから画像ファイルを一時保存
+  def fetch_image_file(message_id)
+    response = client.get_message_content(message_id)
+    file = Tempfile.new(['line_image', '.jpg'])
+    file.binmode
+    file.write(response.body)
+    file.rewind
+    file
+  end
+
+  # Foodオブジェクトの作成(画像あり)
+  def save_food_with_image(file, user, event)
+    temp_food = user.line_messages.last
+    food = Food.new(
+      name: temp_food.temp_name,
+      quantity: temp_food.temp_quantity,
+      expiration_date: temp_food.temp_expiration_date,
+      storage: temp_food.temp_storage.to_i,
+      user_id: user.id,
+      food_image: file
+    )
+
+    file.close
+    file.unlink
+
+    if food.save
+      response_text = "以下の食材が保存されました。\n\n食材名: #{food.name}\n在庫数: #{food.quantity}\n消費期限: #{food.expiration_date}\n保存場所: #{food.storage}"
+    else
+      response_text = 'エラーが発生しました。正しく入力してください。'
+    end
+    user.update(status: 'idle')
+    client.reply_message(event['replyToken'], { type: 'text', text: response_text })
+  end
+
+  # Foodオブジェクトの作成(画像なし)
+  def save_food_without_image(user, event)
+    temp_food = user.line_messages.last
+    food = Food.new(
+      name: temp_food.temp_name,
+      quantity: temp_food.temp_quantity,
+      expiration_date: temp_food.temp_expiration_date,
+      storage: temp_food.temp_storage.to_i,
+      user_id: user.id,
+    )
+
+    if food.save
+      response_text = "以下の食材が保存されました。\n\n食材名: #{food.name}\n在庫数: #{food.quantity}\n消費期限: #{food.expiration_date}\n保存場所: #{food.storage}"
+    else
+      response_text = 'エラーが発生しました。正しく入力してください。'
+    end
+    user.update(status: 'idle')
+    client.reply_message(event['replyToken'], { type: 'text', text: response_text })
+  end
+
+  # エラーの場合の処理
+  def respond_with_error(event)
+    client.reply_message(event['replyToken'], { type: 'text', text: 'エラーが発生しました。正しく入力してください。' })
+    user.update(status: 'idle')
   end
 
   # 食材リストの取得とメッセージ生成

--- a/app/models/line_message.rb
+++ b/app/models/line_message.rb
@@ -1,0 +1,3 @@
+class LineMessage < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   has_many :foods, dependent: :destroy
+  has_many :line_messages, dependent: :destroy
 
   enum status: { idle: 0,
                 waiting_for_recipe: 1,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,14 @@
 class User < ApplicationRecord
   has_many :foods, dependent: :destroy
 
-  enum status: { idle: 0, waiting_for_recipe: 1, waiting_for_food_name: 2 }
+  enum status: { idle: 0,
+                waiting_for_recipe: 1,
+                waiting_add_food_name: 2,
+                waiting_add_food_quantity: 3,
+                waiting_add_food_expiration: 4,
+                waiting_add_food_storage: 5,
+                waiting_add_food_image: 6
+              }
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,

--- a/db/migrate/20240630105319_create_line_messages.rb
+++ b/db/migrate/20240630105319_create_line_messages.rb
@@ -1,7 +1,11 @@
 class CreateLineMessages < ActiveRecord::Migration[7.1]
   def change
     create_table :line_messages do |t|
-      t.string :message_content
+      t.string :temp_name
+      t.string :temp_quantity
+      t.string :temp_expiration_date
+      t.string :temp_storage
+      t.string :temp_image
       t.references :user, null: false, foreign_key: true
 
       t.timestamps

--- a/db/migrate/20240630105319_create_line_messages.rb
+++ b/db/migrate/20240630105319_create_line_messages.rb
@@ -1,0 +1,10 @@
+class CreateLineMessages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :line_messages do |t|
+      t.string :message_content
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_30_105319) do
   end
 
   create_table "line_messages", force: :cascade do |t|
-    t.string "message_content"
+    t.string "temp_name"
+    t.string "temp_quantity"
+    t.string "temp_expiration_date"
+    t.string "temp_storage"
+    t.string "temp_image"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_17_004827) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_30_105319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_004827) do
     t.integer "storage", default: 0, null: false
     t.string "food_image"
     t.index ["user_id"], name: "index_foods_on_user_id"
+  end
+
+  create_table "line_messages", force: :cascade do |t|
+    t.string "message_content"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_line_messages_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -43,4 +51,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_004827) do
   end
 
   add_foreign_key "foods", "users"
+  add_foreign_key "line_messages", "users"
 end


### PR DESCRIPTION
### 実装内容
- [x] userモデルのenum statusの値を追加
- [x] statusの値によってLineからの返答を変更
  - [x]  ユーザー側「食材の登録」と入力後、Line側「食材名を入力してください」と表示される
    - [x]   ユーザー側「食材の名前」を入力後、statusが変更される
  - [x] Line側「数量を入力してください」と表示される
    - [x] ユーザー側「食材の数量」を入力後、statusが変更される
  - [x] Line側「消費期限を入力してください」と表示される
    - [x] ユーザー側「食材の消費期限」を入力後、statusが変更される
  - [x] Line側「保存場所を入力してください」と表示される
    - [x] ユーザー側「食材の保存場所」を入力後、statusが変更される
  - [x] Line側「画像を送信してください。画像を保存しない場合は「スキップ」と入力してください。」と表示される
    - [x] ユーザー側「食材の画像」を送信後、statusが変更される
    - [x] ユーザー側「スキップ」と入力後、statusが変更される
  - [x] Line側に保存された食材の情報が表示される
  - [x] 入力した情報で食材が登録できる
  - [x] ユーザーが入力した情報がフォーマットと違う場合、「エラーが発生しました。正しく入力してください。」と表示される