### PR TITLE
 新規食材の登録時にカテゴリーを選択できる機能を追加 #57 close

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -11,7 +11,6 @@ class FoodsController < ApplicationController
   def new
     @food = current_user.foods.new
     @categories = Category.all
-    @category = @food.category
   end
 
   def create
@@ -28,7 +27,6 @@ class FoodsController < ApplicationController
   def show
     @food = Food.find(params[:id])
     @categories = Category.all
-    @category = @food.category
   end
 
   def edit

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -10,6 +10,8 @@ class FoodsController < ApplicationController
 
   def new
     @food = current_user.foods.new
+    @categories = Category.all
+    @category = @food.category
   end
 
   def create

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -181,9 +181,10 @@ class LineBotController < ApplicationController
   # Foodオブジェクトの作成(画像あり)
   def save_food_with_image(file, user, event)
     temp_food = user.line_messages.last
+    category_id = temp_food.temp_category_id.to_i
     food = Food.new(
       name: temp_food.temp_name,
-      category_id: (1..11).include?(temp_food.temp_category_id) ? temp_food.temp_category_id : nil,
+      category_id: (1..11).include?(category_id) ? category_id : nil,
       quantity: temp_food.temp_quantity,
       expiration_date: temp_food.temp_expiration_date,
       storage: temp_food.temp_storage.to_i,
@@ -206,9 +207,10 @@ class LineBotController < ApplicationController
   # Foodオブジェクトの作成(画像なし)
   def save_food_without_image(user, event)
     temp_food = user.line_messages.last
+    category_id = temp_food.temp_category_id.to_i
     food = Food.new(
       name: temp_food.temp_name,
-      category_id: (1..11).include?(temp_food.temp_category_id) ? temp_food.temp_category_id : nil,
+      category_id: (1..11).include?(category_id) ? category_id : nil,
       quantity: temp_food.temp_quantity,
       expiration_date: temp_food.temp_expiration_date,
       storage: temp_food.temp_storage.to_i,

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -135,9 +135,18 @@ class LineBotController < ApplicationController
         { type: 'text', text: '無効な番号です。もう一度番号を入力してください' }
       end
     when 'waiting_add_food_name'
-      temp_food = user.line_messages.create(temp_name: text)
+      temp_food = user.line_messages.create(temp_name: text )
+      user.update(status: 'waiting_add_category')
+      { type: 'text',
+        text: "カテゴリーを数字で入力してください。\n\n1: 野菜\n 2: 果物\n 3: 水産物・水産加工品\n 4: 肉・肉加工品\n 5: 卵・チーズ・乳製品\n 6: 麺類\n 7: 粉類\n 8: 飲料\n 9: 菓子類\n 10: 調味料\n 11: その他"
+      }
+
+    when 'waiting_add_category'
+      temp_food = user.line_messages.last
+      temp_food.update(temp_category_id: text)
       user.update(status: 'waiting_add_food_quantity')
       { type: 'text', text: '在庫数を数字で入力してください。' }
+
     when 'waiting_add_food_quantity'
       temp_food = user.line_messages.last
       temp_food.update(temp_quantity: text)
@@ -174,6 +183,7 @@ class LineBotController < ApplicationController
     temp_food = user.line_messages.last
     food = Food.new(
       name: temp_food.temp_name,
+      category_id: (1..11).include?(temp_food.temp_category_id) ? temp_food.temp_category_id : nil,
       quantity: temp_food.temp_quantity,
       expiration_date: temp_food.temp_expiration_date,
       storage: temp_food.temp_storage.to_i,
@@ -185,7 +195,7 @@ class LineBotController < ApplicationController
     file.unlink
 
     response_text = if food.save
-                      "以下の食材が保存されました。\n\n食材名: #{food.name}\n在庫数: #{food.quantity}\n消費期限: #{food.expiration_date}\n保存場所: #{food.storage}"
+                      "以下の食材が保存されました。\n\n食材名: #{food.name}\nカテゴリー: #{food.category.name}\n在庫数: #{food.quantity}\n消費期限: #{food.expiration_date}\n保存場所: #{food.storage}"
                     else
                       'エラーが発生しました。正しく入力してください。'
                     end
@@ -198,6 +208,7 @@ class LineBotController < ApplicationController
     temp_food = user.line_messages.last
     food = Food.new(
       name: temp_food.temp_name,
+      category_id: (1..11).include?(temp_food.temp_category_id) ? temp_food.temp_category_id : nil,
       quantity: temp_food.temp_quantity,
       expiration_date: temp_food.temp_expiration_date,
       storage: temp_food.temp_storage.to_i,
@@ -205,7 +216,7 @@ class LineBotController < ApplicationController
     )
 
     response_text = if food.save
-                      "以下の食材が保存されました。\n\n食材名: #{food.name}\n在庫数: #{food.quantity}\n消費期限: #{food.expiration_date}\n保存場所: #{food.storage}"
+                      "以下の食材が保存されました。\n\n食材名: #{food.name}\nカテゴリー: #{food.category.name}\n在庫数: #{food.quantity}\n消費期限: #{food.expiration_date}\n保存場所: #{food.storage}"
                     else
                       'エラーが発生しました。正しく入力してください。'
                     end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Food < ApplicationRecord
+  before_validation :sanitize_category_id
+
   belongs_to :user
-  
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :category
   mount_uploader :food_image, FoodImageUploader
@@ -12,8 +13,17 @@ class Food < ApplicationRecord
   validates :expiration_date, presence: true
   validates :storage, presence: true
   validates :quantity, numericality: { only_integer: true }, presence: true
+  validates :category_id, inclusion: { in: Category.all.map(&:id) }
+
   # Ransackv4.0.0で追加された許可リストの作成
   def self.ransackable_attributes(_auth_object = nil)
     %w[created_at expiration_date name quantity storage updated_at]
   end
+
+  private
+  # カテゴリIDが1〜11かをチェック、範囲外ならnilに設定
+  def sanitize_category_id
+    self.category_id = nil unless Category.all.map(&:id).include?(category_id)
+  end
+
 end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -13,7 +13,7 @@ class Food < ApplicationRecord
   validates :expiration_date, presence: true
   validates :storage, presence: true
   validates :quantity, numericality: { only_integer: true }, presence: true
-  validates :category_id, inclusion: { in: Category.all.map(&:id) }
+  validates :category_id, inclusion: { in: Category.all.map(&:id) }, allow_nil: true
 
   # Ransackv4.0.0で追加された許可リストの作成
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,8 @@ class User < ApplicationRecord
                  waiting_add_food_storage: 5,
                  waiting_add_food_image: 6,
                  waiting_delete_food: 7,
-                 waiting_delete_food_number: 8
+                 waiting_delete_food_number: 8,
+                 waiting_add_category: 9
                  }
 
   devise :database_authenticatable, :registerable,

--- a/app/views/foods/_edit_category_modal.html.erb
+++ b/app/views/foods/_edit_category_modal.html.erb
@@ -18,7 +18,7 @@
     </form>
     <%= form_with model: food, local:true do |f|%>
       <div class='flex items-center mx-auto max-w-xs'>
-        <%= f.collection_select :category_id, @categories, :id, :name, class:"mx-auto text-center" %>
+        <%= f.select :category_id, @categories.map { |category| [category.name, category.id] }, { include_blank: '---' }, class: "mx-auto text-center text-ali" %>
       </div>
       <%= f.submit "変更する", disable_with: '登録中...', class:"btn btn-outline btn-success mt-5"%>
     <% end %>

--- a/app/views/foods/_form.html.erb
+++ b/app/views/foods/_form.html.erb
@@ -4,7 +4,14 @@
   <div class="field mb-8">
     <div class='input input-bordered flex items-center gap-2 mx-auto max-w-xs'>
       <%= f.label :name %>
-      <%= f.text_field :name, class:"text-area mx-auto text-center ", placeholder: "食材名" %>
+      <%= f.text_field :name, class:"text-area mx-auto text-center", placeholder: "食材名" %>
+    </div>
+  </div>
+
+  <div class="field mb-8">
+    <div class='input input-bordered flex items-center gap-2 mx-auto max-w-xs'>
+      <%= f.label :category %>
+      <%= f.select :category_id, @categories.map { |category| [category.name, category.id] }, { include_blank: '---' }, class: "mx-auto text-center" %>
     </div>
   </div>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,6 +10,7 @@ ja:
           refrigerator: 冷蔵庫
           freezer: 冷凍庫
           others: その他
+        category: カテゴリー
     models:
       food: 食材
   date:

--- a/db/migrate/20240716095800_add_category_id_to_line_messages.rb
+++ b/db/migrate/20240716095800_add_category_id_to_line_messages.rb
@@ -1,0 +1,5 @@
+class AddCategoryIdToLineMessages < ActiveRecord::Migration[7.1]
+  def change
+    add_column :line_messages, :temp_category_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_13_084203) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_095800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_13_084203) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_category_id"
     t.index ["user_id"], name: "index_line_messages_on_user_id"
   end
 


### PR DESCRIPTION
### 実装内容
- [x] カテゴリーは以下
    - [x] 野菜
    - [x] 果物
    - [x] 水産物・水産加工品
    - [x] 肉・肉加工品
    - [x] 麺類
    - [x] 粉類
    - [x] 飲料
    - [x] 菓子類
    - [x] 調味料
    - [x] その他
- [x] 新規登録ページにフォームを追加
- [x] LINE上からカテゴリーを選択できるようにコードを追加