### PR TITLE
管理者ユーザー一覧ページの作成 #20 close

### DIFF
--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,8 +1,14 @@
 class Admin::HomesController < ApplicationController
 
   before_action :authenticate_admin!
-  
-  def top
 
+  def top
+    @users = User.all
+  end
+
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to admin_homes_top_path
   end
 end

--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,14 +1,29 @@
 class Admin::HomesController < ApplicationController
-
   before_action :authenticate_admin!
+  before_action :set_user, only: [:show, :destroy]
 
   def top
     @users = User.all
   end
 
+  def show
+    @foods = @user.foods
+  end
+
   def destroy
-    @user = User.find(params[:id])
     @user.destroy
-    redirect_to admin_homes_top_path
+    redirect_to admin_root_path, success: t('defaults.flash_message.deleted', item: User.model_name.human), status: :see_other
+  end
+
+  def destroy_food
+    @food = Food.find(params[:id])
+    @food.destroy
+    redirect_to admin_home_path(@food.user_id), success: t('defaults.flash_message.deleted', item: Food.model_name.human), status: :see_other
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/views/admin/homes/show.html.erb
+++ b/app/views/admin/homes/show.html.erb
@@ -1,0 +1,23 @@
+<div class="container mx-auto text-center">
+  <h1 class="text-3xl font-bold text-center my-5">ユーザーの投稿一覧</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>名前</th>
+        <th>操作</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @foods.each do |food| %>
+        <tr>
+          <td><%= food.id %></td>
+          <td><%= food.name %></td>
+          <td>
+            <%= link_to '削除', admin_destroy_food_path(food), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-md" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,1 +1,25 @@
-<h1>管理者トップページ</h1>
+<div class="container mx-auto text-center">
+  <h1 class="text-3xl font-bold text-center my-5">ユーザー一覧ページ</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>名前</th>
+        <th>Email</th>
+        <th>操作</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td><%= user.id %></td>
+          <td><%= user.name %></td>
+          <td><%= user.email %></td>
+          <td>
+            <%= link_to '削除', admin_destroy_home_path(user), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-md" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -16,7 +16,10 @@
           <td><%= user.name %></td>
           <td><%= user.email %></td>
           <td>
-            <%= link_to '削除', admin_destroy_home_path(user), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-md" %>
+            <%= link_to "詳細", admin_home_path(user), class: "btn btn-outline btn-success btn-xs sm:btn-sm md:btn-md" %>
+          </td>
+          <td>
+            <%= link_to '削除', admin_home_path(user), data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm')}, class: "btn btn-outline btn-error btn-md" %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/shared/_admin_sign_in_header.html.erb
+++ b/app/views/admin/shared/_admin_sign_in_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-slate-400">
   <div class="flex-1">
-    <%= link_to t('header.title'), unauthenticated_root_path, class: 'btn btn-ghost text-xl' %>
+    <%= link_to t('header.title'), admin_root_path, class: 'btn btn-ghost text-xl' %>
   </div>
   <div class="navbar-center hidden sm:flex">
     <ul class="menu menu-horizontal px-1 text-lg">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,8 @@ Rails.application.routes.draw do
   }
   namespace :admin do
     get '/' => 'homes#top', as: :root
-    delete 'homes/:id' => 'homes#destroy', as: :destroy_home
+    resources :homes, only: [:show, :destroy]
+    delete 'destroy_food/:id', to: 'homes#destroy_food', as: 'destroy_food'
   end
 
   # ゲストユーザー機能でControllerをカスタマイズしているので変更

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,9 @@ Rails.application.routes.draw do
   devise_for :admin, skip: [:registrations, :passwords] ,controllers: {
     sessions: "admin/sessions"
   }
-  
   namespace :admin do
     get '/' => 'homes#top', as: :root
+    delete 'homes/:id' => 'homes#destroy', as: :destroy_home
   end
 
   # ゲストユーザー機能でControllerをカスタマイズしているので変更


### PR DESCRIPTION
### 実装内容
- [x] 全てのユーザーの一覧ページの作成
- [x] 管理者がユーザーを削除できる機能の実装
### 補足
ユーザー詳細ページで、そのユーザーが登録した食材を一覧で見れるように実装
ユーザーが登録した食材一覧ページで食材の削除ができるように実装