### PR TITLE
レシピ検索機能のrspec #132 close

### DIFF
--- a/app/controllers/rakuten_recipes_controller.rb
+++ b/app/controllers/rakuten_recipes_controller.rb
@@ -12,6 +12,8 @@ class RakutenRecipesController < ApplicationController
       else
         @recipes = category.ranking
       end
+    else
+      flash.now[:warning] = t('defaults.flash_message.not_keyword')
     end
   end
 # レシピを保存するアクションを追加
@@ -20,7 +22,7 @@ class RakutenRecipesController < ApplicationController
 
     if @recipe.save
       flash[:success] =  t('defaults.flash_message.keep')
-      redirect_to foods_path
+      redirect_to users_profile_path
     else
       flash.now[warning] =  t('defaults.flash_message.not_keep')
       render :search
@@ -30,7 +32,7 @@ class RakutenRecipesController < ApplicationController
   def destroy
     @recipe = current_user.rakuten_recipes.find(params[:id])
     @recipe.destroy
-    redirect_to foods_path, success: t('defaults.flash_message.deleted', item: RakutenRecipe.model_name.human), status: :see_other
+    redirect_to users_profile_path, success: t('defaults.flash_message.delete_keep', item: RakutenRecipe.model_name.human), status: :see_other
   end
 
   private

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -33,6 +33,7 @@ ja:
       not_keyword: "検索ワードを入力してください"
       keep : レシピを保存しました
       not_keep : レシピを保存できませんでした
+      delete_keep : レシピを削除しました
   header:
     title: PantryChefNotifier
     new: 食材登録

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -30,6 +30,7 @@ ja:
       not_edit: "%{item}を編集できませんでした"
       deleted: "%{item}を削除しました"
       not_searched: "検索結果がありません"
+      not_keyword: "検索ワードを入力してください"
       keep : レシピを保存しました
       not_keep : レシピを保存できませんでした
   header:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
   config.include SignInSupport
+  config.include RakutenRecipeMock
 end

--- a/spec/support/rakuten_recipe_mock.rb
+++ b/spec/support/rakuten_recipe_mock.rb
@@ -1,0 +1,13 @@
+module RakutenRecipeMock
+  def search_recipe_mock
+    allow(RakutenWebService::Recipe).to receive(:small_categories).and_return([
+      OpenStruct.new(
+        name: 'にんじん',
+        ranking: [
+          OpenStruct.new(title: 'レシピ1', foodImageUrl: 'https://example.com/recipe1.jpg', recipeTitle: 'レシピ1タイトル'),
+          OpenStruct.new(title: 'レシピ2', foodImageUrl: 'https://example.com/recipe2.jpg', recipeTitle: 'レシピ2タイトル')
+        ]
+      )
+    ])
+  end
+end

--- a/spec/system/rakuten_recipes_spec.rb
+++ b/spec/system/rakuten_recipes_spec.rb
@@ -23,7 +23,9 @@ describe 'RakutenRecipesController' do
 
     context '検索ワードが入力されていない場合' do
       it '検索ワードを入力してくださいと表示される' do
-
+        fill_in 'keyword', with: ''
+        click_on '検索する'
+        expect(page).to have_content('検索ワードを入力してください')
       end
     end
 

--- a/spec/system/rakuten_recipes_spec.rb
+++ b/spec/system/rakuten_recipes_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+describe 'RakutenRecipesController' do
+  describe 'レシピ検索' do
+    context '検索ワードが入力されている場合' do
+      it '検索結果が表示される' do
+
+      end
+    end
+
+    context '検索ワードが入力されていない場合' do
+      it '検索ワードを入力してくださいと表示される' do
+
+      end
+    end
+
+    context '検索結果が存在しない場合' do
+      it '検索結果がありませんと表示される' do
+
+      end
+    end
+  end
+
+  describe 'レシピのお気に入り登録' do
+    context 'レシピが保存された場合' do
+      it 'レシピを保存しましたと表示される' do
+
+      end
+      it 'マイページにお気に入りしたレシピが表示されている' do
+
+      end
+    end
+
+    context 'お気に入りしたレシピを削除する場合' do
+      it 'レシピを削除しましたと表示される' do
+
+      end
+      it 'マイページからお気に入りしたレシピが削除されている' do
+        
+      end
+    end
+  end
+end

--- a/spec/system/rakuten_recipes_spec.rb
+++ b/spec/system/rakuten_recipes_spec.rb
@@ -4,14 +4,11 @@ describe 'RakutenRecipesController' do
 
   before do
     sign_in(user)
+    search_recipe_mock
     visit search_rakuten_recipes_path
   end
 
   describe 'レシピ検索' do
-    before do
-      search_recipe_mock
-    end
-
     context '検索ワードが入力されている場合' do
       it '検索結果が表示される' do
         fill_in 'keyword', with: 'にんじん'
@@ -40,20 +37,28 @@ describe 'RakutenRecipesController' do
 
   describe 'レシピのお気に入り登録' do
     context 'レシピが保存された場合' do
-      it 'レシピを保存しましたと表示される' do
-
-      end
-      it 'マイページにお気に入りしたレシピが表示されている' do
-
+      it 'レシピを保存しましたと表示され、マイページにお気に入りしたレシピが表示されている' do
+        fill_in 'keyword', with: 'にんじん'
+        click_on '検索する'
+        click_on 'お気に入りに追加', match: :first
+        expect(current_path).to eq(users_profile_path)
+        expect(page).to have_content('レシピを保存しました')
+        expect(page).to have_content('レシピ1')
       end
     end
 
     context 'お気に入りしたレシピを削除する場合' do
-      it 'レシピを削除しましたと表示される' do
-
+      before do
+        fill_in 'keyword', with: 'にんじん'
+        click_on '検索する'
+        click_on 'お気に入りに追加', match: :first
+        expect(current_path).to eq(users_profile_path)
       end
-      it 'マイページからお気に入りしたレシピが削除されている' do
 
+      it 'レシピを削除しましたと表示され、' do
+        click_on '削除', match: :first
+        expect(page).to have_content('レシピを削除しました')
+        expect(page).not_to have_content('レシピ1')
       end
     end
   end

--- a/spec/system/rakuten_recipes_spec.rb
+++ b/spec/system/rakuten_recipes_spec.rb
@@ -6,9 +6,10 @@ describe 'RakutenRecipesController' do
     sign_in(user)
     visit search_rakuten_recipes_path
   end
-
+  
   describe 'レシピ検索' do
     before do
+      # small_categoriesのモックを設定
       allow(RakutenWebService::Recipe).to receive(:small_categories).and_return([
         OpenStruct.new(
           name: 'にんじん',
@@ -37,7 +38,9 @@ describe 'RakutenRecipesController' do
 
     context '検索結果が存在しない場合' do
       it '検索結果がありませんと表示される' do
-        
+        fill_in 'keyword', with: 'カレー'
+        click_on '検索する'
+        expect(page).to have_content('検索結果がありません')
       end
     end
   end

--- a/spec/system/rakuten_recipes_spec.rb
+++ b/spec/system/rakuten_recipes_spec.rb
@@ -1,9 +1,31 @@
 require 'rails_helper'
 describe 'RakutenRecipesController' do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+    visit search_rakuten_recipes_path
+  end
+
   describe 'レシピ検索' do
+    before do
+      allow(RakutenWebService::Recipe).to receive(:small_categories).and_return([
+        OpenStruct.new(
+          name: 'にんじん',
+          ranking: [
+            OpenStruct.new(title: 'レシピ1', foodImageUrl: 'https://example.com/recipe1.jpg', recipeTitle: 'レシピ1タイトル'),
+            OpenStruct.new(title: 'レシピ2', foodImageUrl: 'https://example.com/recipe2.jpg', recipeTitle: 'レシピ2タイトル')
+          ]
+        )
+      ])
+    end
+
     context '検索ワードが入力されている場合' do
       it '検索結果が表示される' do
-
+        fill_in 'keyword', with: 'にんじん'
+        click_on '検索する'
+        expect(page).to have_content('レシピ1')
+        expect(page).to have_content('レシピ2')
       end
     end
 
@@ -15,7 +37,7 @@ describe 'RakutenRecipesController' do
 
     context '検索結果が存在しない場合' do
       it '検索結果がありませんと表示される' do
-
+        
       end
     end
   end
@@ -35,7 +57,7 @@ describe 'RakutenRecipesController' do
 
       end
       it 'マイページからお気に入りしたレシピが削除されている' do
-        
+
       end
     end
   end

--- a/spec/system/rakuten_recipes_spec.rb
+++ b/spec/system/rakuten_recipes_spec.rb
@@ -6,19 +6,10 @@ describe 'RakutenRecipesController' do
     sign_in(user)
     visit search_rakuten_recipes_path
   end
-  
+
   describe 'レシピ検索' do
     before do
-      # small_categoriesのモックを設定
-      allow(RakutenWebService::Recipe).to receive(:small_categories).and_return([
-        OpenStruct.new(
-          name: 'にんじん',
-          ranking: [
-            OpenStruct.new(title: 'レシピ1', foodImageUrl: 'https://example.com/recipe1.jpg', recipeTitle: 'レシピ1タイトル'),
-            OpenStruct.new(title: 'レシピ2', foodImageUrl: 'https://example.com/recipe2.jpg', recipeTitle: 'レシピ2タイトル')
-          ]
-        )
-      ])
+      search_recipe_mock
     end
 
     context '検索ワードが入力されている場合' do


### PR DESCRIPTION
### 実装内容
- [x] レシピをキーワードで検索することができる。
- [x] 検索ワードを入力しないで検索した場合、「kwんサクワードをにゅうろくしてください」と表示される。
- [x] 該当するキーワードがない場合、「検索結果がありません」と表示される。
- [x] お気に入り登録をすることができる。
- [x] お気に入りをしたレシピを削除できる。

補足
- お気に入り追加と保存したレシピの削除した場合の遷移先をマイページに変更
- フラッシュメッセージの文を変更